### PR TITLE
プレイヤー入力の受付

### DIFF
--- a/app_tick_tack_toe/game.py
+++ b/app_tick_tack_toe/game.py
@@ -1,0 +1,76 @@
+from board import Board
+from coordinate import Coordinate, InvalidCoordinateException
+from player import Player
+
+
+class StartPhase:
+    """ 開始処理として、開始メッセージ・初期盤面の表示を責務に持つ """
+    START_MESSAGE = 'start'
+
+    def proceed(self, board: Board):
+        """
+        phase進行として、開始メッセージ・初期盤面を表示
+
+        :param board: 盤面
+        """
+        print(self.START_MESSAGE)
+        print(board.view)
+
+
+class MainPhase:
+    INPUT_PROMPT = '手を入力してください。\n'
+    END_INPUT = 'END'
+
+    def proceed(self, board: Board):
+        """
+        メインのゲームループを実行
+
+        :param board: 盤面
+        """
+        player = Player()
+
+        while True:
+            raw_input = self._read_input()
+
+            # 終了判定
+            if raw_input == self.END_INPUT:
+                return
+
+            # 盤面更新
+            coordinate = Coordinate(player.get_mark(), board.size)
+            try:
+                coordinate.assign(raw_input)
+            except InvalidCoordinateException as e:
+                print(e.MESSAGE)
+                continue
+
+            board.update(coordinate)
+            print(board.view)
+            player.change()
+
+    def _read_input(self) -> str:
+        """
+        ユーザの入力値を受け取る
+
+        :return: 入力文字列
+        """
+        return input(self.INPUT_PROMPT)
+
+
+class EndPhase:
+    pass
+
+
+class Game:
+
+    def __init__(self):
+        self._phases = [StartPhase(), MainPhase()]
+
+    def start(self):
+        board = Board()
+        [phase.proceed(board) for phase in self._phases]
+
+
+if __name__ == '__main__':
+    game = Game()
+    game.start()

--- a/app_tick_tack_toe/tests/game_test.py
+++ b/app_tick_tack_toe/tests/game_test.py
@@ -1,0 +1,70 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from .expected.board import get_initial_board
+from ..game import StartPhase, MainPhase
+from ..board import Board
+from ..coordinate import InvalidCoordinateException
+
+
+class TestStartPhase:
+
+    def test_init(self, capfd: pytest.CaptureFixture):
+        # GIVEN
+        expected_board = get_initial_board()
+        expected = f'{StartPhase.START_MESSAGE}\n{expected_board}'
+        board = Board()
+
+        # WHEN
+        sut = StartPhase()
+        sut.proceed(board)
+
+        actual = capfd.readouterr().out
+        # THEN
+        assert actual == expected
+
+
+class TestMainPhase:
+
+    def _create_user_input_mock(self, side_effects: list[str], mocker: MockerFixture):
+        """
+        ユーザ入力のモックを生成
+
+        :param side_effects: ユーザ入力値のリスト
+        :param mocker: MockerFixture
+        """
+
+        input_mock = mocker.Mock()
+        input_mock.side_effect = side_effects
+        mocker.patch.object(MainPhase, '_read_input', input_mock)
+
+    def test_print_invalid_coordinate(self, capfd: pytest.CaptureFixture, mocker: MockerFixture):
+        # GIVEN
+        board = Board()
+        expected = f'{InvalidCoordinateException.MESSAGE}\n'
+
+        self._create_user_input_mock(['invalid', MainPhase.END_INPUT], mocker)
+
+        # WHEN
+        sut = MainPhase()
+        sut.proceed(board)
+
+        # THEN
+        actual = capfd.readouterr().out
+        assert actual == expected
+
+    def test_update_coordinate(self, mocker: MockerFixture):
+        # GIVEN
+        board = Board()
+        expected = '○'
+
+        self._create_user_input_mock(['0,0', MainPhase.END_INPUT], mocker)
+
+        # WHEN
+        sut = MainPhase()
+        sut.proceed(board)
+
+        actual = board.coordinate[(0, 0)]
+
+        # THEN
+        assert actual == expected


### PR DESCRIPTION
## 入力の受付

座標形式の入力を受け取れるようにしたい。
入力形式は、`1,2`, `1,  2`, ` 1,  2 `のように2つの数値をカンマで連結し、任意の数のスペースを含むものとする。

入力から座標オブジェクトを生成し、バリデーション。
妥当な入力の場合は、座標をもとに盤面を更新。
不正な値の場合は、メッセージを表示して再度入力を促す。

---



### TODO

input関数をモック化し、戻り値を固定したい。更に、繰り返し呼び出す度に戻り値を変えることで、
擬似的にユーザが繰り返し入力した状況をつくりだしたい。
今後のCLIのテストでも使うことになりそうなので、しっかりと身につけたい。
[読む](https://docs.pytest.org/en/6.2.x/monkeypatch.html)

→pytest-mockを使うことにした。
モック関数を連続で呼び出したときの戻り値を指定できれば解決しそう。
その辺りをもう少し調べてみるか。

→ `Mock.side_effect`へイテラブルを渡せばいけるっぽい。
[参考](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.side_effect)

inputをモック化してテストできた。

---

### メインループの生成

`END`が入力されるまで好きに盤面を埋められるようにしたい。

#### 必要な機能

* ゲームループ
* 入力判定 座標判定の前に終了判定が必要か
* ENDの場合は処理終了
* END以外は続行とする