### PR TITLE
プレイヤークラスのリファクタ

### DIFF
--- a/app_tick_tack_toe/player.py
+++ b/app_tick_tack_toe/player.py
@@ -1,21 +1,29 @@
+import dataclasses
+
+
+@dataclasses.dataclass
+class Candidate:
+    """ 現在プレイヤーの候補 """
+    PLAYER_1: str = 'FIRST'
+    PLAYER_2: str = 'SECOND'
+
+
+@dataclasses.dataclass
+class Mark:
+    """ 盤面へ印字する記号 """
+    FIRST: str = '○'
+    SECOND: str = '×'
+
+
 class Player:
     """ ゲームのプレイヤーの状態管理を責務に持つ """
 
-    # 現在プレイヤーの候補
-    CANDIDATE = {
-        'player1': '1p',
-        'player2': '2p'
-    }
-
-    # 盤面へ印字する記号
-    MARK = {
-        '1p': '○',
-        '2p': '×'
-    }
+    CANDIDATE: Candidate = Candidate()
+    MARK: Mark = Mark()
 
     def __init__(self):
         # 現在プレイヤー
-        self.current = self.CANDIDATE['player1']
+        self.current = self.CANDIDATE.PLAYER_1
 
     def get_mark(self):
         """
@@ -24,15 +32,15 @@ class Player:
         :return: ○ or ×
         """
 
-        return self.MARK[self.current]
+        return self.MARK.__getattribute__(self.current)
 
     def change(self):
         """
         プレイヤーを切り替え
         """
 
-        if self.current == self.CANDIDATE['player1']:
-            self.current = self.CANDIDATE['player2']
+        if self.current == self.CANDIDATE.PLAYER_1:
+            self.current = self.CANDIDATE.PLAYER_2
             return
 
-        self.current = self.CANDIDATE['player1']
+        self.current = self.CANDIDATE.PLAYER_1

--- a/app_tick_tack_toe/tests/player_test.py
+++ b/app_tick_tack_toe/tests/player_test.py
@@ -3,7 +3,7 @@ from ..player import Player
 
 def test_initial_state():
     # GIVEN
-    expected = Player.CANDIDATE['player1']
+    expected = Player.CANDIDATE.PLAYER_1
     sut = Player()
 
     # WHEN
@@ -15,8 +15,8 @@ def test_initial_state():
 
 def test_toggle_1p_to_2p():
     # GIVEN
-    expected = [Player.CANDIDATE['player1'], Player.CANDIDATE['player2'], Player.CANDIDATE['player1'],
-                Player.CANDIDATE['player2']]
+    expected = [Player.CANDIDATE.PLAYER_1, Player.CANDIDATE.PLAYER_2, Player.CANDIDATE.PLAYER_1,
+                Player.CANDIDATE.PLAYER_2]
     sut = Player()
 
     # WHEN


### PR DESCRIPTION
## 概要

これまで、プレイヤークラスの定数は辞書で管理していた。
しかし、辞書は補完が効かず、タイプミスをカバーするのが困難になっていた。

固定のキーのもの・ループなどで加工するのでなければ、データの保持が目的であることも踏まえ、
dataclassへ移行したい。

### やること

* 既存のプレイヤークラスのファイルへ、定数管理用のデータクラスを追加
* プレイヤークラスのクラス定数へデータクラスを追加
* プレイヤークラスの定数へアクセスしている処理は、辞書アクセスから属性アクセスへ書き換え
* テストコードで動作検証