### PR TITLE
盤面クラスの責務分割

### DIFF
--- a/app_tick_tack_toe/board.py
+++ b/app_tick_tack_toe/board.py
@@ -1,46 +1,50 @@
+import dataclasses
+
 from string_builder import StringBuilder
 from coordinate import Coordinate
 
+# 盤面のマスの初期値
+INITIAL_BOARD_MARK = '!'
 
-class Board:
-    """ 盤面を表示する要素の保持を責務に持つ"""
 
-    # 盤面のマスの初期値
-    INITIAL_MARK = '!'
-    # マスの間の区切り線
-    BORDER_LINE = '---- ---- ----'
+@dataclasses.dataclass
+class BoardStatus:
+    """ 盤面の状態管理を責務に持つ """
+    coordinate: dict[tuple[int, int], str]
+    size: int
 
-    def __init__(self, size=3):
-        self.size = size
-        # マスの初期化
-        self.coordinate = {(x, y): self.INITIAL_MARK
+    def __post_init__(self):
+        self.coordinate = {(x, y): INITIAL_BOARD_MARK
                            for x in range(0, self.size)
                            for y in range(0, self.size)}
 
-        self.view = self._generate_view()
 
-    def update(self, coordinate: Coordinate):
-        """
-        盤面を座標で更新
+class BoardView:
+    """ 盤面の表示部分を責務に持つ """
 
-        :param coordinate: 更新対象の座標
-        """
+    # マスの間の区切り線
+    BORDER_LINE = '---- ---- ----'
 
-        self.coordinate[(coordinate.x, coordinate.y)] = coordinate.value
-        self.view = self._generate_view()
+    def __init__(self, status: BoardStatus):
+        self.status = status
+
+    def __str__(self):
+        return self._generate_view()
 
     def _generate_view(self) -> str:
         """
-        盤面文字列の生成
+        盤面文字列の生成 具体的な文字列はドキュメント参照
 
         :return: 文字列化した盤面
         """
         builder = StringBuilder()
-        for y in range(0, self.size):
+
+        # 横列を1行ずつ構築
+        for y in range(0, self.status.size):
             builder.append_line(self._generate_mark_line(y))
 
             # 末尾行は改行を含むと不自然な空白行が出力されてしまうので、改行なしとする
-            is_tail = y == self.size - 1
+            is_tail = y == self.status.size - 1
             builder.append(self.BORDER_LINE) if is_tail else builder.append_line(self.BORDER_LINE)
 
         return builder.text
@@ -56,18 +60,40 @@ class Board:
         # 描画のバランスを考慮すると、空白は一律同一ではなく、間隔を変えた方が見映えがいい
         # よって、位置ごとの空白を保持しておく
         space = {'head': '  ', 'mid': '    ', 'tail': ''}
-        marks = [self.coordinate[line_number, x] for x in range(0, self.size)]
+        marks = [self.status.coordinate[line_number, x] for x in range(0, self.status.size)]
 
-        for i in range(0, self.size):
+        # 「  !    !    !」のようにマークを印字
+        for i in range(0, self.status.size):
             # 先頭
             if i == 0:
                 builder.append(f'{space["head"]}{marks[i]}')
                 continue
-            # 中間
-            if i == self.size - 1:
+            # 末尾
+            if i == self.status.size - 1:
                 builder.append(f'{space["mid"]}{marks[i]}{space["tail"]}')
                 continue
-            # 末尾
+            # 中間
             builder.append(f'{space["mid"]}{marks[i]}')
 
         return builder.text
+
+
+class Board:
+    """ 盤面を表示する要素の保持を責務に持つ"""
+
+    def __init__(self, size=3):
+        self.status = BoardStatus(size=size, coordinate={})
+        self.view = BoardView(self.status)
+
+    @property
+    def size(self):
+        return self.status.size
+
+    def update(self, coordinate: Coordinate):
+        """
+        盤面を座標で更新
+
+        :param coordinate: 更新対象の座標
+        """
+
+        self.status.coordinate[(coordinate.x, coordinate.y)] = coordinate.value


### PR DESCRIPTION
## 概要

既存の盤面クラスは、表示のみを責務に持つ。
だが、現時点でも属性が多く、ここへ勝敗判定などを追加すると、表示とロジックを分離するのが困難になる。

よって、盤面の大元・表示・勝敗判定と責務を分散できるよう、クラスを分割。
あわせて、属性もデータクラスでよりコンパクトにまとめる。


### やること

* 盤面の表示関連の定数や大きさなどをデータクラスで統合
* 盤面クラスを盤面表示用クラスへ切り出し、表示ロジックを委譲するよう構成変更
* 呼び出し元を見直し、責務を切り分けたクラスを扱えるよう修正

* テストコードの見直し